### PR TITLE
Use dbus-glib from shared-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.mozilla.Firefox.BaseApp.json
+++ b/org.mozilla.Firefox.BaseApp.json
@@ -4,29 +4,9 @@
     "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "separate-locales": false,
-    "cleanup": [
-        "*.la",
-        "/bin",
-        "/etc",
-        "/include",
-        "/libexec",
-        "/share/gtk-doc",
-        "/share/man"
-    ],
     "modules": [
       {
-          "name": "dbus-glib",
-          "config-opts": [
-              "--disable-static",
-              "--disable-gtk-doc"
-          ],
-          "sources": [
-              {
-                  "type": "archive",
-                  "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.108.tar.gz",
-                  "sha256": "9f340c7e2352e9cdf113893ca77ca9075d9f8d5e81476bf2bf361099383c602c"
-              }
-          ]
+        "shared-modules/dbus-glib/dbus-glib-0.110.json"
       }
     ]
 }


### PR DESCRIPTION
This simplify the manifest and also update dbus-glib to latest release. 0.108 was over 3 years old.