### PR TITLE
Build only x86_64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+    "only-arches": ["x86_64"],
     "skip-appstream-check": true
 }


### PR DESCRIPTION
AFAIK mozilla produces official releases only for x86_64 and i686[1]  thus building for arm is pointless.

[1] https://archive.mozilla.org/pub/firefox/releases/70.0.1/