### PR TITLE
Now we cannot create issues anymore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "shared-modules"]
 	path = shared-modules
 	url = https://github.com/flathub/shared-modules
+ 
+ 


### PR DESCRIPTION
So I cannot even read your answer to the previous question what this repo is.

As I assume it is outdated/etc., I assume it would be better not to close the issues (so nobody can read them anymore and some were useful for historical reference), but *achieve* the whole repo, so it is read-only…

You can [archive this repository](https://help.github.com/articles/archiving-repositories/), to mark it as unmaintained. People then cannot submit PRs and there is a big warning that this is archived.
Remember to add a note to the Readme before to explain that it is unmaintained, and – if you think this is useful – why and probably mention alternatives.