### PR TITLE
Add mount point for ffmpeg-ful extension

### DIFF
--- a/org.mozilla.Firefox.BaseApp.json
+++ b/org.mozilla.Firefox.BaseApp.json
@@ -13,6 +13,9 @@
         "/share/man",
         "*.la", "*.a"
     ],
+    "cleanup-commands": [
+        "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
+    ],
     "modules": [
         "shared-modules/gtk2/gtk2.json",
         "shared-modules/dbus-glib/dbus-glib-0.110.json",


### PR DESCRIPTION
/app/lib/ffmpeg dir must exist in order to mount ffmpeg-full extension