### PR TITLE
Create README.md with link to upstream source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+## This is a build dependency of Firefox and not the app itself. You want to install `org.mozilla.firefox` instead.
+The source code for the upstream `org.mozilla.firefox` flatpak can be found here: https://hg.mozilla.org/mozilla-central/file/tip/taskcluster/docker/firefox-flatpak

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ## This is a build dependency of Firefox and not the app itself. You want to install `org.mozilla.firefox` instead.
 The source code for the upstream `org.mozilla.firefox` flatpak can be found:
- * On mozilla's Mercurial repository: https://hg.mozilla.org/mozilla-central/file/tip/taskcluster/docker/firefox-flatpak
+ * On Mozilla's Mercurial repository: https://hg.mozilla.org/mozilla-central/file/tip/taskcluster/docker/firefox-flatpak
  * On GitHub (read-only): https://github.com/mozilla/gecko-dev/tree/master/taskcluster/docker/firefox-flatpak

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 ## This is a build dependency of Firefox and not the app itself. You want to install `org.mozilla.firefox` instead.
-The source code for the upstream `org.mozilla.firefox` flatpak can be found here: https://hg.mozilla.org/mozilla-central/file/tip/taskcluster/docker/firefox-flatpak
+The source code for the upstream `org.mozilla.firefox` flatpak can be found:
+ * On mozilla's Mercurial repository: https://hg.mozilla.org/mozilla-central/file/tip/taskcluster/docker/firefox-flatpak
+ * On GitHub (read-only): https://github.com/mozilla/gecko-dev/tree/master/taskcluster/docker/firefox-flatpak


### PR DESCRIPTION
Borrowing from b9808d56eb6d6ab61b486f0f5e4085748bbe1f37, with a notice that this is not the right package, and adds a link to the upstream repo for the `org.mozilla.firefox` package, to help those trying to find it.

Does it look too ugly being an h2, should it look different?