### PR TITLE
Enable cups module as print backend by using gtk's settings.ini

### DIFF
--- a/gtk-settings.ini
+++ b/gtk-settings.ini
@@ -1,0 +1,2 @@
+[Settings]
+gtk-print-backends=file,cups

--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -95,6 +95,19 @@
                     "path": "gtk3-werror.patch"
                 }
             ]
+        },
+        {
+            "name": "gtk-settings",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm 644 gtk-settings.ini /app/etc/xdg/gtk-3.0/settings.ini"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "gtk-settings.ini"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Fixing bug https://bugzilla.mozilla.org/show_bug.cgi?id=1712555
Stolen from https://github.com/flathub/org.chromium.Chromium