### PR TITLE
Build firefox for aarch64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-    "only-arches": ["x86_64"],
+    "only-arches": ["aarch64", "x86_64"],
     "skip-appstream-check": true
 }


### PR DESCRIPTION
Right now, this package does not exist on Flathub if you are using an ARM based image like Ubuntu for aarch64 virtualized on Apple hardware.