### PR TITLE
Bug 1825842 - Fix Thunderbird Flatpak notification sounds

### DIFF
--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -16,6 +16,8 @@
     ],
     "modules": [
         "shared-modules/dbus-glib/dbus-glib.json",
+        "shared-modules/libcanberra/libcanberra.json",
+        "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "kerberos",
             "subdir": "src",
@@ -54,6 +56,16 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.2.tar.xz",
                     "sha256": "c5f4ed3d1f86e5b118c76415aacb861873ed3e6f0c6b3181b828cf584fc5c616"
+                }
+            ]
+        },
+        {
+            "name": "sound-theme-freedesktop",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://salsa.debian.org/gnome-team/sound-theme-freedesktop.git",
+                    "tag": "upstream/0.8"
                 }
             ]
         },


### PR DESCRIPTION
The upcoming official Flatpak build of Thunderbird relies on org.mozilla.firefox.BaseApp for dependencies just like the Firefox Flatpak.

Currently, notification sounds do not work on the official Thunderbird Flatpak because of missing dependencies on libcanberra, intltool, and the FreeDesktop sound theme.

This patch fixes notification sounds.