### PR TITLE
Bump libnotify to 0.8.3

### DIFF
--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -60,8 +60,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.2.tar.xz",
-                    "sha256": "c5f4ed3d1f86e5b118c76415aacb861873ed3e6f0c6b3181b828cf584fc5c616"
+                    "url": "https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.3.tar.xz",
+                    "sha256": "ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0"
                 }
             ]
         },


### PR DESCRIPTION
0.8.3 fixed a crash when applications were running inside sandbox, it affected electron apps but no idea if anything else was affected too. Let's update to avoid that. https://gitlab.gnome.org/GNOME/libnotify/-/issues/34