### PR TITLE
Add libspeechd

### DIFF
--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -98,6 +98,22 @@
             ]
         },
         {
+            "name": "dotconf",
+            "cleanup": ["*"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/williamh/dotconf/archive/refs/tags/v1.3.tar.gz",
+                    "sha256": "7f1ecf40de1ad002a065a321582ed34f8c14242309c3547ad59710ae3c805653"
+                },
+                {
+                    "type": "script",
+                    "commands": "autoreconf -fiv",
+                    "dest-filename": "autogen.sh"
+                }
+            ]
+        },
+        {
             "name": "libspeechd",
             "config-opts": [
                     "--disable-python",

--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -121,7 +121,12 @@
                     "--disable-python",
                     "--with-systemdsystemunitdir=''",
                     "--disable-rpath",
-                    "--disable-static"
+                    "--disable-static",
+                    "--with-kali=no",
+                    "--with-baratinoo=no",
+                    "--with-ibmtts=no",
+                    "--with-voxin=no",
+                    "--without-oss"
             ],
             "sources": [
                 {

--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -10,6 +10,8 @@
         "/share/pkgconfig",
         "/share/aclocal",
         "/share/gtk-doc",
+        "/share/doc",
+        "/share/info",
         "/man",
         "/share/man",
         "*.la", "*.a"
@@ -131,7 +133,8 @@
             "cleanup": [
                 "/bin",
                 "/etc",
-                "/lib/speech-dispatcher"
+                "/libexec",
+                "/share"
             ]
         }
     ]

--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -96,6 +96,27 @@
                     "sha256": "d85195b9139d120cb6ba20199a19d3ef4aecdb7922eaead62994c704ea3da19e"
                 }
             ]
+        },
+        {
+            "name": "libspeechd",
+            "config-opts": [
+                    "--disable-python",
+                    "--with-systemdsystemunitdir=''",
+                    "--disable-rpath",
+                    "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/brailcom/speechd/releases/download/0.11.5/speech-dispatcher-0.11.5.tar.gz",
+                    "sha256": "1ce4759ffabbaf1aeb433a5ec0739be0676e9bdfbae9444a7b3be1b2af3ec12b"
+                }
+            ],
+            "cleanup": [
+                "/bin",
+                "/etc",
+                "/lib/speech-dispatcher"
+            ]
         }
     ]
 }

--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -139,6 +139,7 @@
                 "/bin",
                 "/etc",
                 "/libexec",
+                "/lib/speech-dispatcher",
                 "/share/sounds/speech-dispatcher",
                 "/share/speech-dispatcher"
             ]

--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -134,7 +134,8 @@
                 "/bin",
                 "/etc",
                 "/libexec",
-                "/share"
+                "/share/sounds/speech-dispatcher",
+                "/share/speech-dispatcher"
             ]
         }
     ]

--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -108,7 +108,7 @@
                 },
                 {
                     "type": "script",
-                    "commands": "autoreconf -fiv",
+                    "commands": ["autoreconf -fiv"],
                     "dest-filename": "autogen.sh"
                 }
             ]


### PR DESCRIPTION
libspeechd is required to make speech synthesis work in firefox

https://searchfox.org/mozilla-central/source/dom/media/webspeech/synth/speechd/SpeechDispatcherService.cpp#321

https://bugzilla.mozilla.org/show_bug.cgi?id=1638150

Access to speech host socket is also necessary.