### PR TITLE
json: Update PCSC from 2.0.0 to 2.0.1

### DIFF
--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -85,7 +85,8 @@
                 "--without-systemdsystemunitdir",
                 "--disable-serial",
                 "--disable-usb",
-                "--disable-documentation"
+                "--disable-documentation",
+                "--disable-polkit"
             ],
             "post-install": [
                 "rm /app/sbin/pcscd",

--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -94,8 +94,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://salsa.debian.org/rousseau/PCSC/-/archive/2.0.0/PCSC-2.0.0.tar.bz2",
-                    "sha256": "d85195b9139d120cb6ba20199a19d3ef4aecdb7922eaead62994c704ea3da19e"
+                    "url": "https://salsa.debian.org/rousseau/PCSC/-/archive/2.0.1/PCSC-2.0.1.tar.bz2",
+                    "sha256": "c6e0629c80db91ade4bc6db69a0c21b7fe8b610d04dc5c21153038a74b9db4bf"
                 }
             ]
         },


### PR DESCRIPTION
PCSC updated from 2.0.0 to 2.0.1
Changelog: https://salsa.debian.org/rousseau/PCSC/-/commit/932d77d7c93c39d8308451497425db1962f53b55#00fe7828d56d7a3ee4030d6cea057cf13f50e70c