### PR TITLE
Build on aarch64 too

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
-    "only-arches": ["x86_64"],
     "skip-appstream-check": true,
     "end-of-life": "This BaseApp is meant to be used by Firefox and Thunderbird, and should not be installed directly."
 }


### PR DESCRIPTION
No reason not to, see https://blog.nightly.mozilla.org/2024/04/19/firefox-nightly-now-available-for-linux-on-arm64/