### PR TITLE
Drop dbus-glib

### DIFF
--- a/org.mozilla.firefox.BaseApp.json
+++ b/org.mozilla.firefox.BaseApp.json
@@ -17,7 +17,6 @@
         "*.la", "*.a"
     ],
     "modules": [
-        "shared-modules/dbus-glib/dbus-glib.json",
         "shared-modules/libcanberra/libcanberra.json",
         "shared-modules/intltool/intltool-0.51.json",
         {


### PR DESCRIPTION
Firefox removed this dependency in v120

See https://bugzilla.mozilla.org/show_bug.cgi?id=1532281